### PR TITLE
Fix undefined elem when hiding success box

### DIFF
--- a/public/templates/example.html
+++ b/public/templates/example.html
@@ -44,6 +44,7 @@
         return res;
     }
     function copyWithSignCommand() {
+        var successBox = document.getElementById("success");
         successBox.innerText = "";
         console.log('Copying...');
         var code = getVerificationCode();


### PR DESCRIPTION
Redefine `successBox` since it's out of scope